### PR TITLE
Add missing xof.final in expand_view_challenge_hash

### DIFF
--- a/Optimized_Implementation/Threshold_Variant/sdith_threshold_cat1_gf256/views.c
+++ b/Optimized_Implementation/Threshold_Variant/sdith_threshold_cat1_gf256/views.c
@@ -8,6 +8,7 @@ void expand_view_challenge_hash(uint16_t* opened_views, const uint8_t* digest, u
     xof_context entropy_ctx;
     xof_init(&entropy_ctx);
     xof_update(&entropy_ctx, digest, PARAM_DIGEST_SIZE);
+    xof_final(&entropy_ctx);
     samplable_t entropy = xof_to_samplable(&entropy_ctx);
 
     uint16_t ind = 0;

--- a/Optimized_Implementation/Threshold_Variant/sdith_threshold_cat1_p251/views.c
+++ b/Optimized_Implementation/Threshold_Variant/sdith_threshold_cat1_p251/views.c
@@ -8,6 +8,7 @@ void expand_view_challenge_hash(uint16_t* opened_views, const uint8_t* digest, u
     xof_context entropy_ctx;
     xof_init(&entropy_ctx);
     xof_update(&entropy_ctx, digest, PARAM_DIGEST_SIZE);
+    xof_final(&entropy_ctx);
     samplable_t entropy = xof_to_samplable(&entropy_ctx);
 
     uint16_t ind = 0;

--- a/Optimized_Implementation/Threshold_Variant/sdith_threshold_cat3_gf256/views.c
+++ b/Optimized_Implementation/Threshold_Variant/sdith_threshold_cat3_gf256/views.c
@@ -8,6 +8,7 @@ void expand_view_challenge_hash(uint16_t* opened_views, const uint8_t* digest, u
     xof_context entropy_ctx;
     xof_init(&entropy_ctx);
     xof_update(&entropy_ctx, digest, PARAM_DIGEST_SIZE);
+    xof_final(&entropy_ctx);
     samplable_t entropy = xof_to_samplable(&entropy_ctx);
 
     uint16_t ind = 0;

--- a/Optimized_Implementation/Threshold_Variant/sdith_threshold_cat3_p251/views.c
+++ b/Optimized_Implementation/Threshold_Variant/sdith_threshold_cat3_p251/views.c
@@ -8,6 +8,7 @@ void expand_view_challenge_hash(uint16_t* opened_views, const uint8_t* digest, u
     xof_context entropy_ctx;
     xof_init(&entropy_ctx);
     xof_update(&entropy_ctx, digest, PARAM_DIGEST_SIZE);
+    xof_final(&entropy_ctx);
     samplable_t entropy = xof_to_samplable(&entropy_ctx);
 
     uint16_t ind = 0;

--- a/Optimized_Implementation/Threshold_Variant/sdith_threshold_cat5_gf256/views.c
+++ b/Optimized_Implementation/Threshold_Variant/sdith_threshold_cat5_gf256/views.c
@@ -8,6 +8,7 @@ void expand_view_challenge_hash(uint16_t* opened_views, const uint8_t* digest, u
     xof_context entropy_ctx;
     xof_init(&entropy_ctx);
     xof_update(&entropy_ctx, digest, PARAM_DIGEST_SIZE);
+    xof_final(&entropy_ctx);
     samplable_t entropy = xof_to_samplable(&entropy_ctx);
 
     uint16_t ind = 0;

--- a/Optimized_Implementation/Threshold_Variant/sdith_threshold_cat5_p251/views.c
+++ b/Optimized_Implementation/Threshold_Variant/sdith_threshold_cat5_p251/views.c
@@ -8,6 +8,7 @@ void expand_view_challenge_hash(uint16_t* opened_views, const uint8_t* digest, u
     xof_context entropy_ctx;
     xof_init(&entropy_ctx);
     xof_update(&entropy_ctx, digest, PARAM_DIGEST_SIZE);
+    xof_final(&entropy_ctx);
     samplable_t entropy = xof_to_samplable(&entropy_ctx);
 
     uint16_t ind = 0;

--- a/Reference_Implementation/Threshold_Variant/sdith_threshold_cat1_gf256/views.c
+++ b/Reference_Implementation/Threshold_Variant/sdith_threshold_cat1_gf256/views.c
@@ -8,6 +8,7 @@ void expand_view_challenge_hash(uint16_t* opened_views, const uint8_t* digest, u
     xof_context entropy_ctx;
     xof_init(&entropy_ctx);
     xof_update(&entropy_ctx, digest, PARAM_DIGEST_SIZE);
+    xof_final(&entropy_ctx);
     samplable_t entropy = xof_to_samplable(&entropy_ctx);
 
     uint16_t ind = 0;

--- a/Reference_Implementation/Threshold_Variant/sdith_threshold_cat1_p251/views.c
+++ b/Reference_Implementation/Threshold_Variant/sdith_threshold_cat1_p251/views.c
@@ -8,6 +8,7 @@ void expand_view_challenge_hash(uint16_t* opened_views, const uint8_t* digest, u
     xof_context entropy_ctx;
     xof_init(&entropy_ctx);
     xof_update(&entropy_ctx, digest, PARAM_DIGEST_SIZE);
+    xof_final(&entropy_ctx);
     samplable_t entropy = xof_to_samplable(&entropy_ctx);
 
     uint16_t ind = 0;

--- a/Reference_Implementation/Threshold_Variant/sdith_threshold_cat3_gf256/views.c
+++ b/Reference_Implementation/Threshold_Variant/sdith_threshold_cat3_gf256/views.c
@@ -8,6 +8,7 @@ void expand_view_challenge_hash(uint16_t* opened_views, const uint8_t* digest, u
     xof_context entropy_ctx;
     xof_init(&entropy_ctx);
     xof_update(&entropy_ctx, digest, PARAM_DIGEST_SIZE);
+    xof_final(&entropy_ctx);
     samplable_t entropy = xof_to_samplable(&entropy_ctx);
 
     uint16_t ind = 0;

--- a/Reference_Implementation/Threshold_Variant/sdith_threshold_cat3_p251/views.c
+++ b/Reference_Implementation/Threshold_Variant/sdith_threshold_cat3_p251/views.c
@@ -8,6 +8,7 @@ void expand_view_challenge_hash(uint16_t* opened_views, const uint8_t* digest, u
     xof_context entropy_ctx;
     xof_init(&entropy_ctx);
     xof_update(&entropy_ctx, digest, PARAM_DIGEST_SIZE);
+    xof_final(&entropy_ctx);
     samplable_t entropy = xof_to_samplable(&entropy_ctx);
 
     uint16_t ind = 0;

--- a/Reference_Implementation/Threshold_Variant/sdith_threshold_cat5_gf256/views.c
+++ b/Reference_Implementation/Threshold_Variant/sdith_threshold_cat5_gf256/views.c
@@ -8,6 +8,7 @@ void expand_view_challenge_hash(uint16_t* opened_views, const uint8_t* digest, u
     xof_context entropy_ctx;
     xof_init(&entropy_ctx);
     xof_update(&entropy_ctx, digest, PARAM_DIGEST_SIZE);
+    xof_final(&entropy_ctx);
     samplable_t entropy = xof_to_samplable(&entropy_ctx);
 
     uint16_t ind = 0;

--- a/Reference_Implementation/Threshold_Variant/sdith_threshold_cat5_p251/views.c
+++ b/Reference_Implementation/Threshold_Variant/sdith_threshold_cat5_p251/views.c
@@ -8,6 +8,7 @@ void expand_view_challenge_hash(uint16_t* opened_views, const uint8_t* digest, u
     xof_context entropy_ctx;
     xof_init(&entropy_ctx);
     xof_update(&entropy_ctx, digest, PARAM_DIGEST_SIZE);
+    xof_final(&entropy_ctx);
     samplable_t entropy = xof_to_samplable(&entropy_ctx);
 
     uint16_t ind = 0;


### PR DESCRIPTION
Dear SDitH Team,

We are currently writing our masters thesis on implementing the SDith protocol in Rust. Currently we have a working implementation of the protocol.

While implementing the sdith protocol we had trouble comparing outputs between our implementations and specifically comparing to your test vectors due to inconsistencies in the XOF state. For this specifically, there seems to be missing a `xof_final` in the `expand_view_challenge_hash` to create a consistent PRG state.

Here is a PR to fix it. The change should only leave it a bit easier for future implementors.

I'm unable to run the optimized version on my macbook M2 due to AVX2, so we've not been able to recompute the KAT files.

Greetings from Benjamin & Magnus